### PR TITLE
Riorganizza il CSS responsive della pagina principale

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,537 +7,268 @@
   <link rel="manifest" href="./manifest.webmanifest">
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
-    .glass{backdrop-filter:blur(12px);background:rgba(255,255,255,.6)}
-    .tag{font-size:.75rem;padding:.125rem .5rem;border-radius:999px;border:1px solid rgba(0,0,0,.1)}
-    .card:hover{transform:translateY(-2px);transition:.2s}
-    .modal-open{overflow:hidden}
+    .glass { backdrop-filter: blur(12px); background: rgba(255, 255, 255, .6); }
+    .tag { font-size: .75rem; padding: .125rem .5rem; border-radius: 999px; border: 1px solid rgba(0, 0, 0, .1); }
+    .card:hover { transform: translateY(-2px); transition: .2s; }
+    .modal-open { overflow: hidden; }
 
-    /* la tabella può allargarsi quanto serve */
     #quoteTable {
       table-layout: auto;
       min-width: max-content;
     }
-    #quoteTable th:nth-child(3),
-    #quoteTable th:nth-child(4),
-    #quoteTable th:nth-child(5),
-    #quoteTable th:nth-child(6),
-    #quoteTable th:nth-child(7),
-    #quoteTable th:nth-child(8),
-    #quoteTable td:nth-child(3),
-    #quoteTable td:nth-child(4),
-    #quoteTable td:nth-child(5),
-    #quoteTable td:nth-child(6),
-    #quoteTable td:nth-child(7),
-    #quoteTable td:nth-child(8){
+
+    #quoteTable th:nth-child(n+3):nth-child(-n+8),
+    #quoteTable td:nth-child(n+3):nth-child(-n+8) {
       white-space: nowrap;
     }
+
     .quoteTableWrap { overflow: visible; }
-    #quoteTable input[type="number"]{ width: 5.5rem; }
-    #quotePanel{ overflow-x: auto; }
+    #quoteTable input[type="number"] { width: 5.5rem; }
+    #quotePanel { overflow-x: auto; }
     .quote-desc { white-space: normal; word-break: break-word; line-height: 1.25; }
-    #quotePanel button{ white-space: nowrap; }
-    #categoryList button { text-align: left; display: block; width: 100%; }
-    #listinoContainer table { width: 100%; table-layout: fixed; word-break: break-word; }
-/* --- Categorie orizzontali su cellulare (<768px) --- */
-@media (max-width:767px) {
-  #categoryList {
-    display: flex;
-    overflow-x: auto;
-    gap: .5rem;
-    flex-wrap: nowrap;
-  }
-  #categoryList button {
-    flex: 0 0 auto;
-    width: auto;
-    display: inline-block;
-  }
-}
-
-/* --- Tablet (768–1199px) e Desktop (>=1200px) → categorie verticali (default) --- */
-/* non serve codice, restano come già sono (block w-full) */
-
-
-/* ===== Tablet: categorie con scroll verticale indipendente ===== */
-
-/* Tablet larghi: 900–1199px → 2 colonne: [categorie | prodotti] */
-@media (min-width:900px) and (max-width:1199.98px){
-  main {
-    display: grid;
-    grid-template-columns: 300px minmax(0,1fr);
-    gap: 1rem;
-  }
-  main > aside:last-of-type { display: none; }
-
-  #catsSticky{
-    position: sticky;
-    top: 92px;
-    max-height: calc(100dvh - 92px - 16px);
-    overflow-y: auto;
-  }
-
-  #categoryList { display: block; overflow: hidden; }
-  #categoryList button { display: block; width: 100%; }
-}
-
-/* Tablet stretti: 768–899px → 1 colonna, ma categorie sticky con scroll interno */
-@media (min-width:768px) and (max-width:899.98px){
-  #catsSticky{
-    position: sticky;
-    top: 92px;
-    max-height: calc(100dvh - 92px - 16px);
-    overflow-y: auto;
-  }
-
-  #categoryList { display: block; overflow: hidden; }
-  #categoryList button { display: block; width: 100%; }
-
-  main > aside:last-of-type { display: none; }
-}
-   /* ===== Tablet: categorie visibili con SCROLL VERTICALE, prodotti al massimo ===== */
-
-/* Tablet stretti: 768–899px → 1 colonna, categorie sticky con scroll; prodotti sotto, larghi */
-@media (min-width:768px) and (max-width:899.98px){
-  /* Preventivo destro nascosto: su tablet usi il drawer */
-  main > aside:last-of-type { display: none; }
-
-  /* CATEGORIE: riquadro verticale con scroll indipendente (restano visibili) */
-  #catsSticky{
-    position: sticky;
-    top: 92px;                          /* allinea sotto l’header sticky */
-    max-height: calc(100dvh - 92px - 16px);
-    overflow-y: auto;                   /* <-- SCORRIMENTO VERTICALE */
-  }
-
-  /* Mantieni lista verticale (no chip orizzontali) */
-  #categoryList { display: block; overflow: hidden; }
-  #categoryList button { display: block; width: 100%; }
-
-  /* AREA PRODOTTI: riempi tutta la larghezza disponibile del contenitore */
-  #listinoContainer { overflow-x: auto; }
-  #listinoContainer table { width: 100%; table-layout: fixed; }
-}
-
-/* Tablet larghi: 900–1199px → 2 colonne [categorie | prodotti]; categorie scroll verticali */
-@media (min-width:900px) and (max-width:1199.98px){
-  /* Griglia: colonna categorie + colonna prodotti che occupa il resto */
-  main{
-    display: grid;
-    grid-template-columns: 300px minmax(0,1fr);  /* puoi ridurre 300→280 se vuoi più spazio ai prodotti */
-    gap: 1rem;
-  }
-
-  /* Preventivo destro nascosto: su tablet usi il drawer */
-  main > aside:last-of-type { display: none; }
-
-  /* CATEGORIE: sempre visibili con scroll verticale indipendente */
-  #catsSticky{
-    position: sticky;
-    top: 92px;
-    max-height: calc(100dvh - 92px - 16px);
-    overflow-y: auto;                   /* <-- SCORRIMENTO VERTICALE */
-  }
-
-  #categoryList { display: block; overflow: hidden; }
-  #categoryList button { display: block; width: 100%; }
-
-  /* PRODOTTI: occupano tutto lo spazio della seconda colonna */
-  #listinoContainer { overflow-x: auto; }
-  #listinoContainer table { width: 100%; table-layout: fixed; }
-} 
-
-/* ===== Tablet (lg Tailwind): 1024–1199px =====
-   Forza il layout a 2 colonne: [categorie | prodotti],
-   e neutralizza i col-span di Tailwind sui figli. */
-@media (min-width:1024px) and (max-width:1199.98px){
-  /* 2 colonne: 300px categorie + resto ai prodotti */
-  main{
-    display: grid !important;
-    grid-template-columns: 300px minmax(0,1fr) !important;
-    gap: 1rem !important;
-  }
-
-  /* Posizionamento esplicito dei 3 blocchi (ordine DOM: aside sx, section, aside dx) */
-  main > aside:first-of-type{         /* CATEGORIE */
-    grid-column: 1 / 2 !important;
-  }
-  main > section{                     /* PRODOTTI */
-    grid-column: 2 / 3 !important;
-    min-width: 0 !important;          /* IMPORTANTISSIMO: consente di occupare tutto lo spazio */
-  }
-  main > aside:last-of-type{          /* PREVENTIVO: nascosto (usiamo il drawer) */
-    display: none !important;
-  }
-
-  /* Assicura che la tabella riempia la colonna prodotti */
-  #listinoContainer{ overflow-x: auto; }
-  #listinoContainer table{
-    width: 100% !important;
-    table-layout: fixed;
-  }
-
-  /* Categorie: riquadro con scroll verticale indipendente (se hai messo id="catsSticky") */
-  #catsSticky{
-    position: sticky;
-    top: 92px; /* allinea sotto l'header sticky */
-    max-height: calc(100dvh - 92px - 16px);
-    overflow-y: auto;
-  }
-}
-/* ===== Drawer Preventivo full-width su tablet (768–1199px) ===== */
-@media (min-width:768px) and (max-width:1199.98px){
-  /* Il pannello si allarga a TUTTA la larghezza del viewport */
-  #drawerQuote{
-  width: auto;
-  max-width: 100vw;
-    left: 0 !important;     /* assicura copertura totale */
-    right: 0 !important;
-  }
-
-  /* Riduci padding interno per guadagnare spazio utile */
-  #drawerQuote #drawerContent{
-    padding: 8px 8px !important;
-  }
-
-  /* Assicura che il contenuto del preventivo sfrutti tutto lo spazio */
-  #drawerQuote #quotePanel{
-    width: 100% !important;
-    min-width: 100% !important;
-    display: block !important;
-  }
-
-  /* Dentro il preventivo: abilita scroll orizzontale della tabella se serve */
-  #drawerQuote .quoteTableWrap{
-    overflow-x: auto !important;
-  }
-
-  /* La tabella può estendersi oltre la larghezza, mantenendo colonne larghe */
-  #drawerQuote #quoteTable{
-    min-width: max-content !important;
-    table-layout: auto !important;
-  }
-}
-/* ===== Drawer Preventivo su tablet: porta a capo descrizione ===== */
-@media (min-width:768px) and (max-width:1199.98px){
-  /* Celle descrizione: testo a capo */
-  #drawerQuote #quoteTable td:nth-child(2),
-  #drawerQuote #quoteTable th:nth-child(2) {
-    white-space: normal !important;
-    word-break: break-word !important;
-    line-height: 1.3;
-  }
-
-  /* Assicura che la tabella usi 100% della larghezza disponibile */
-  #drawerQuote #quoteTable {
-    width: 100% !important;
-    table-layout: fixed !important;
-  }
-}
-
-/* ===== Desktop (>=1200px): solo categorie + prodotti a tutta larghezza ===== */
-@media (min-width:1200px){
-  /* griglia a 2 colonne: categorie fisse + prodotti elastici */
-  main{
-    display: grid !important;
-    grid-template-columns: 280px minmax(0,1fr) !important; /* 280 → puoi variare 260–320 */
-    gap: 1rem !important;
-  }
-  /* nascondi definitivamente l'aside destro (preventivo): ora usiamo il drawer */
-  main > aside:last-of-type{ display: none !important; }
-  /* forza posizionamento: aside sx in colonna 1, section prodotti in colonna 2 */
-  main > aside:first-of-type{ grid-column: 1 / 2 !important; }
-  main > section{ grid-column: 2 / 3 !important; min-width: 0 !important; }
-}
-
-/* ===== Tabelle prodotti: descrizione a capo, colonne numeriche strette ===== */
-#listinoContainer table{ width:100%; table-layout: fixed; }
-#listinoContainer th.col-desc, 
-#listinoContainer td.col-desc{
-  white-space: normal !important;
-  overflow-wrap: anywhere;          /* spezza parole lunghissime */
-  word-break: break-word;           /* fallback */
-  line-height: 1.3;
-}
-#listinoContainer th.col-code,  #listinoContainer td.col-code  { width: 9rem;  white-space: nowrap; }
-#listinoContainer th.col-unit,  #listinoContainer td.col-unit  { width: 9rem;  white-space: nowrap; }
-#listinoContainer th.col-price, #listinoContainer td.col-price { width: 8rem;  white-space: nowrap; text-align:right; }
-#listinoContainer th.col-conai, #listinoContainer td.col-conai { width: 8rem;  white-space: nowrap; text-align:right; }
-#listinoContainer th.col-img,   #listinoContainer td.col-img   { width: 5rem;  white-space: nowrap; text-align:center; }
-
-
-/* Drawer Preventivo: a tutto schermo da 768px in su (anche desktop) */
-@media (min-width:768px){
-  #drawerQuote{
-    width: 100vw !important;
-    max-width: none !important;
-    left: 0 !important;
-    right: 0 !important;
-  }
-  #drawerQuote #drawerContent{
-    padding: 8px 8px !important;          /* margini minimi per guadagnare spazio */
-  }
-  #drawerQuote #quotePanel{
-    width: 100% !important;
-    min-width: 100% !important;
-    display: block !important;
-  }
-  #drawerQuote .quoteTableWrap{
-    overflow-x: auto !important;           /* scroll orizzontale se serve */
-  }
-  #drawerQuote #quoteTable{
-    min-width: max-content !important;     /* consenti colonne larghe */
-    table-layout: auto !important;
-  }
-  /* Descrizione a capo nel drawer (la colonna 2 nella tua tabella) */
-  #drawerQuote #quoteTable td:nth-child(2),
-  #drawerQuote #quoteTable th:nth-child(2){
-    white-space: normal !important;
-    word-break: break-word !important;
-    line-height: 1.3;
-  }
-}
-
-    /* Colonna "Sel" sempre in una riga */
-#listinoContainer th:first-child,
-#listinoContainer td:first-child {
-  white-space: nowrap;
-  text-align: center;
-  vertical-align: middle;
-}
-
-/* === PHONE PORTRAIT: descrizione in UNA riga, tabella scorrevole === */
-@media (max-width: 767.98px) and (orientation: portrait){
-
-  /* il contenitore può scorrere orizzontalmente */
-  #listinoContainer { 
-    overflow-x: auto; 
-  }
-
-  /* la tabella può allargarsi quanto serve */
-  #listinoContainer table {
-    min-width: max-content;    /* più robusto di 720px perché segue il contenuto */
-    table-layout: auto;        /* lascia respirare le colonne */
-  }
-
-  /* Descrizione: UNA riga, niente spezzature */
-  .col-desc {
-    white-space: nowrap !important;
-    word-break: normal !important;
-    overflow: visible;         /* assicurati che non ci siano clip */
-    hyphens: none;             /* evita sillabazione automatica */
-  }
-
-  /* Le tecniche restano compatte (già lo sono, ribadisco) */
-  .col-code, .col-unit, .col-price, .col-conai { 
-    white-space: nowrap; 
-  }
-}
-
-/* === PHONE PORTRAIT: tabella con max 2 righe di descrizione === */
-@media (max-width: 767.98px) and (orientation: portrait){
-
-  #listinoContainer table {
-    table-layout: fixed !important;
-    width: 100% !important;
-  }
-
-  /* Codice compatto */
-  .col-code { width: 90px; }
-
-  /* Descrizione: massimo 2 righe */
-  .col-desc { 
-    width: 200px; 
-    white-space: normal !important;     /* permette di andare a capo */
-    overflow: hidden;                   /* nasconde oltre */
-    display: -webkit-box;
-    -webkit-line-clamp: 2;              /* max 2 righe */
-    -webkit-box-orient: vertical;
-    line-height: 1.3;
-  }
-
-  .col-unit   { width: 100px; }
-  .col-price  { width: 90px; text-align: right; }
-  .col-conai  { width: 90px; text-align: right; }
-  .col-img    { width: 60px; text-align: center; }
-}
-
-
-
-/* ===== SOLO CELLULARE VERTICALE (portrait) ===== */
-@media (max-width: 767.98px) and (orientation: portrait) {
-  /* Categorie tutte in una riga, scroll orizzontale */
-  #categoryList {
-    display: flex;
-    flex-wrap: nowrap;
-    overflow-x: auto;
-    gap: .5rem;
-  }
-  #categoryList button {
-    flex: 0 0 auto;
-    white-space: nowrap;
-  }
-
-  /* Tabella prodotti → descrizione su una riga sola con scroll */
-  #listinoContainer table {
-    table-layout: auto;
-    min-width: max-content; /* permette scorrimento orizzontale */
-  }
-  #listinoContainer td.col-desc {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis; /* ... se troppo lunga */
-    max-width: 300px; /* regola tu il limite */
-  }
-}
-
-
-
-
-    /* === FIX specifico: Phone portrait (<768px) === */
-@media (max-width: 767.98px) and (orientation: portrait){
-  /* Il contenitore consente lo scroll orizzontale */
-  #listinoContainer{ overflow-x:auto !important; }
-
-  /* La tabella può allargarsi, non collassare */
-  #listinoContainer table{
-    min-width: 680px !important;   /* 640–760: regola in base a quante colonne vuoi */
-    table-layout: auto !important;
-    width: auto !important;
-  }
-
-  /* Tutte le colonne “tecniche” restano su una riga */
-  th.col-code, td.col-code,
-  th.col-unit, td.col-unit,
-  th.col-price,td.col-price,
-  th.col-conai,td.col-conai{
-    white-space: nowrap !important;
-  }
-
-  /* Descrizione: UNA riga, non andare a capo */
-  th.col-desc, td.col-desc{
-    white-space: nowrap !important;
-  }
-  /* Se vuoi tagliare con puntini (consigliato su phone) */
-  td.col-desc{
-    max-width: 360px !important;   /* aumenta/diminuisci */
-    overflow: hidden !important;
-    text-overflow: ellipsis !important;
-  }
-
-  /* Categorie: chip su una sola riga con scroll orizzontale */
-  #categoryList{
-    display:flex !important;
-    flex-wrap:nowrap !important;
-    gap:.5rem;
-    overflow-x:auto !important;
-  }
-  #categoryList button{
-    flex:0 0 auto; white-space:nowrap;
-  }
-}
-
- /* Phone portrait: evita la rottura per lettera sulla colonna Dimensione */
-@media (max-width: 767.98px) and (orientation: portrait){
-  th.col-dim, td.col-dim{
-    white-space: nowrap !important;   /* tieni su una riga */
-    word-break: normal !important;    /* non spezzare ogni carattere */
-    overflow: hidden;
-    text-overflow: ellipsis;          /* … se troppo lungo */
-    max-width: 160px;                 /* regola se vuoi più/meno spazio */
-  }
-}
-   
-
-/* Colonna Descrizione: mantieni i bordi della cella ma limita il testo */
-@media (max-width: 767.98px) and (orientation: portrait){
-  .col-desc .desc-text{
-    display: -webkit-box;
-    -webkit-line-clamp: 2;         /* massimo 2 righe */
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    line-height: 1.3;
-  }
-}
-/* ===== Tablet (768–1199px): descrizione max 2 righe ===== */
-@media (min-width:768px) and (max-width:1199.98px) {
-  #listinoContainer td.col-desc {
-    display: -webkit-box;
-    -webkit-line-clamp: 2;         /* massimo 2 righe */
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    white-space: normal !important;  /* consenti a capo */
-    line-height: 1.3;
-  }
-}
-  /* ===== Tablet (768–1199px): descrizione e dimensione su una riga intera ===== */
-@media (min-width:768px) and (max-width:1199.98px) {
-  #listinoContainer td.col-desc,
-  #listinoContainer th.col-desc,
-  #listinoContainer td.col-dim,
-  #listinoContainer th.col-dim {
-    white-space: nowrap !important;   /* tutto su una riga */
-    overflow: visible !important;     /* niente troncamenti */
-    text-overflow: clip !important;   /* no "..." */
-  }
-}  
-
-/* ===== Tablet (768–1199px): tabella larga + no spezzature ===== */
-@media (min-width:768px) and (max-width:1199.98px){
-  /* il contenitore può scrollare in orizzontale */
-  #listinoContainer{ overflow-x:auto !important; }
-
-  /* la tabella si allarga quanto serve (niente fixed) */
-  #listinoContainer table{
-    min-width: 1200px !important;   /* regola se vuoi più/meno spazio */
-    table-layout: auto !important;
-  }
-
-  /* allinea meglio le celle */
-  #listinoContainer th, 
-  #listinoContainer td{
-    vertical-align: top;
-  }
-
-  /* larghezze consigliate per non “strizzare” il testo */
-  #listinoContainer .col-code  { width:120px !important; white-space:nowrap; }
-  #listinoContainer .col-desc  {
-    min-width:420px !important;
-    white-space:nowrap !important;
-    word-break:normal !important;
-    overflow-wrap:normal !important;   /* niente spezzature strane */
-    text-overflow:clip !important;
-  }
-  #listinoContainer .col-dim   {
-    min-width:220px !important;
-    white-space:nowrap !important;
-    word-break:normal !important;
-    overflow-wrap:normal !important;
-  }
-  #listinoContainer .col-unit  { width:140px !important; white-space:nowrap; }
-  #listinoContainer .col-price,
-  #listinoContainer .col-conai { width:120px !important; white-space:nowrap; text-align:right; }
-  #listinoContainer .col-img   { width:80px  !important; text-align:center; white-space:nowrap; }
-}
-
-/* === Logo header === */
-#siteLogo{
-  width: 140px;      /* imposta qui la tua larghezza “pre-stabilita” */
-  height: auto;      /* mantiene le proporzioni dell’SVG */
-  display: block;
-  margin-left: 40px; /* ← aumenta o diminuisci il valore */
-}
-@media (max-width: 767.98px){
-  #siteLogo{ width: 120px; }  /* opzionale: leggermente più piccolo su mobile */
-}
-
-
-/* evidenzia match ricerca */
-.highlight {
-  background: #fff3a3;
-  border-radius: .2rem;
-  padding: 0 .12em;
-}
-
-    
+    #quotePanel button { white-space: nowrap; }
+
+    #categoryList button {
+      display: block;
+      width: 100%;
+      text-align: left;
+    }
+
+    #listinoContainer table {
+      width: 100%;
+      table-layout: fixed;
+      word-break: break-word;
+    }
+
+    #listinoContainer th.col-desc,
+    #listinoContainer td.col-desc {
+      white-space: normal !important;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+      line-height: 1.3;
+    }
+
+    #listinoContainer th.col-code,
+    #listinoContainer td.col-code { width: 9rem; white-space: nowrap; }
+
+    #listinoContainer th.col-unit,
+    #listinoContainer td.col-unit { width: 9rem; white-space: nowrap; }
+
+    #listinoContainer th.col-price,
+    #listinoContainer td.col-price,
+    #listinoContainer th.col-conai,
+    #listinoContainer td.col-conai {
+      width: 8rem;
+      white-space: nowrap;
+      text-align: right;
+    }
+
+    #listinoContainer th.col-img,
+    #listinoContainer td.col-img {
+      width: 5rem;
+      white-space: nowrap;
+      text-align: center;
+    }
+
+    #listinoContainer th:first-child,
+    #listinoContainer td:first-child {
+      white-space: nowrap;
+      text-align: center;
+      vertical-align: middle;
+    }
+
+    #siteLogo {
+      width: 140px;
+      height: auto;
+      display: block;
+      margin-left: 40px;
+    }
+
+    .highlight {
+      background: #fff3a3;
+      border-radius: .2rem;
+      padding: 0 .12em;
+    }
+
+    @media (max-width: 767.98px) {
+      #categoryList {
+        display: flex;
+        gap: .5rem;
+        flex-wrap: nowrap;
+        overflow-x: auto;
+      }
+
+      #categoryList button {
+        display: inline-block;
+        flex: 0 0 auto;
+        width: auto;
+        white-space: nowrap;
+      }
+
+      #listinoContainer {
+        overflow-x: auto;
+      }
+
+      #listinoContainer table {
+        min-width: max-content;
+        table-layout: auto;
+      }
+
+      #listinoContainer th.col-desc,
+      #listinoContainer td.col-desc {
+        white-space: nowrap !important;
+        max-width: 360px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      #listinoContainer th.col-code,
+      #listinoContainer td.col-code,
+      #listinoContainer th.col-unit,
+      #listinoContainer td.col-unit,
+      #listinoContainer th.col-price,
+      #listinoContainer td.col-price,
+      #listinoContainer th.col-conai,
+      #listinoContainer td.col-conai {
+        white-space: nowrap;
+      }
+
+      #siteLogo { width: 120px; }
+    }
+
+    @media (min-width: 768px) and (max-width: 899.98px) {
+      main > aside:last-of-type { display: none; }
+
+      #catsSticky {
+        position: sticky;
+        top: 92px;
+        max-height: calc(100dvh - 92px - 16px);
+        overflow-y: auto;
+      }
+
+      #categoryList { overflow: hidden; }
+
+      #listinoContainer {
+        overflow-x: auto;
+      }
+    }
+
+    @media (min-width: 900px) and (max-width: 1199.98px) {
+      main {
+        display: grid;
+        grid-template-columns: 300px minmax(0, 1fr);
+        gap: 1rem;
+      }
+
+      main > aside:last-of-type { display: none; }
+
+      #catsSticky {
+        position: sticky;
+        top: 92px;
+        max-height: calc(100dvh - 92px - 16px);
+        overflow-y: auto;
+      }
+
+      #categoryList { overflow: hidden; }
+      #listinoContainer { overflow-x: auto; }
+    }
+
+    @media (min-width: 1024px) and (max-width: 1199.98px) {
+      main {
+        display: grid !important;
+        grid-template-columns: 300px minmax(0, 1fr) !important;
+        gap: 1rem !important;
+      }
+
+      main > aside:first-of-type { grid-column: 1 / 2 !important; }
+      main > section { grid-column: 2 / 3 !important; min-width: 0 !important; }
+      main > aside:last-of-type { display: none !important; }
+    }
+
+    @media (min-width: 1200px) {
+      main {
+        display: grid !important;
+        grid-template-columns: 280px minmax(0, 1fr) !important;
+        gap: 1rem !important;
+      }
+
+      main > aside:first-of-type { grid-column: 1 / 2 !important; }
+      main > section { grid-column: 2 / 3 !important; min-width: 0 !important; }
+      main > aside:last-of-type { display: none !important; }
+    }
+
+    @media (min-width: 768px) and (max-width: 1199.98px) {
+      #listinoContainer table {
+        min-width: 1200px !important;
+        table-layout: auto !important;
+      }
+
+      #listinoContainer th,
+      #listinoContainer td {
+        vertical-align: top;
+      }
+
+      #listinoContainer .col-code { width: 120px !important; }
+      #listinoContainer .col-desc {
+        min-width: 420px !important;
+        display: -webkit-box;
+        -webkit-line-clamp: 2;
+        -webkit-box-orient: vertical;
+        overflow: hidden;
+        white-space: normal !important;
+        word-break: normal !important;
+        overflow-wrap: normal !important;
+        text-overflow: clip !important;
+        line-height: 1.3;
+      }
+
+      #listinoContainer .col-dim {
+        min-width: 220px !important;
+        white-space: nowrap !important;
+        word-break: normal !important;
+        overflow-wrap: normal !important;
+      }
+
+      #listinoContainer .col-unit { width: 140px !important; }
+      #listinoContainer .col-price,
+      #listinoContainer .col-conai { width: 120px !important; }
+      #listinoContainer .col-img { width: 80px !important; }
+    }
+
+    @media (min-width: 768px) {
+      #drawerQuote {
+        width: 100vw !important;
+        max-width: none !important;
+        left: 0 !important;
+        right: 0 !important;
+      }
+
+      #drawerQuote #drawerContent {
+        padding: 8px 8px !important;
+      }
+
+      #drawerQuote #quotePanel {
+        width: 100% !important;
+        min-width: 100% !important;
+        display: block !important;
+      }
+
+      #drawerQuote .quoteTableWrap {
+        overflow-x: auto !important;
+      }
+
+      #drawerQuote #quoteTable {
+        min-width: max-content !important;
+        table-layout: auto !important;
+      }
+
+      #drawerQuote #quoteTable td:nth-child(2),
+      #drawerQuote #quoteTable th:nth-child(2) {
+        white-space: normal !important;
+        word-break: break-word !important;
+        line-height: 1.3;
+      }
+    }
   </style>
 </head>
 <body class="bg-white text-slate-900">


### PR DESCRIPTION
## Summary
- semplify and deduplicate the inline CSS of the landing page to improve readability
- harmonize breakpoints for categories, product table and quote drawer to remove conflicting rules

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4afd826e08321bb4c493f8ab59777