### PR TITLE
Force horizontal category layout on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,56 @@
     .quote-desc { white-space: normal; word-break: break-word; line-height: 1.25; }
     #quotePanel button { white-space: nowrap; }
 
-    #categoryList button {
-      display: block;
+    .category-list {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+    }
+
+    .category-list button {
+      display: inline-flex;
+      align-items: center;
+      justify-content: flex-start;
       width: 100%;
       text-align: left;
+    }
+
+    .category-list.orientation-vertical {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+    }
+
+    .category-list.orientation-horizontal {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: nowrap;
+      overflow-x: auto;
+      padding-bottom: 0.25rem;
+    }
+
+    .category-list.orientation-horizontal button {
+      flex: 0 0 auto;
+      width: auto !important;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      white-space: nowrap;
+      text-align: center;
+    }
+
+    .category-list.orientation-vertical button {
+      justify-content: flex-start;
+    }
+
+    .category-list .category-break {
+      width: 100%;
+      height: 0;
+      margin: 0.5rem 0;
+    }
+
+    .category-list.orientation-horizontal .category-break {
+      display: none;
     }
 
     #listinoContainer table {
@@ -147,20 +193,6 @@
 
       .header-controls button {
         width: auto;
-      }
-
-      #categoryList {
-        display: flex;
-        gap: .5rem;
-        flex-wrap: nowrap;
-        overflow-x: auto;
-      }
-
-      #categoryList button {
-        display: inline-block;
-        flex: 0 0 auto;
-        width: auto;
-        white-space: nowrap;
       }
 
       #listinoContainer {
@@ -320,7 +352,7 @@
         overflow-y: auto;
       }
 
-      #categoryList { overflow: hidden; }
+      #categoryList.orientation-vertical { overflow: hidden; }
 
       #listinoContainer {
         overflow-x: auto;
@@ -343,7 +375,7 @@
         overflow-y: auto;
       }
 
-      #categoryList { overflow: hidden; }
+      #categoryList.orientation-vertical { overflow: hidden; }
       #listinoContainer { overflow-x: auto; }
     }
 
@@ -516,15 +548,18 @@
       <!-- SX -->
     <!-- SX: CATEGORIE / FILTRI -->
 <aside class="hidden lg:block lg:col-span-3">
-  <div id="catsSticky" class="glass rounded-2xl p-4 border">
-    <h2 class="font-semibold text-left mb-3">Categorie</h2>
+  <div id="categoryPanelDesktopAnchor">
+    <div id="catsSticky" class="glass rounded-2xl p-4 border">
+      <div class="flex items-center justify-between mb-3 gap-3">
+        <h2 class="font-semibold text-left">Categorie</h2>
+      </div>
 
-    <!-- PILLS CATEGORIE -->
-    <div id="categoryList" class="grid grid-cols-1 gap-2 text-left"></div>
+      <!-- PILLS CATEGORIE -->
+      <div id="categoryList" class="category-list gap-2 text-left"></div>
 
 
 
-   
+    </div>
   </div>
 </aside>
 
@@ -539,6 +574,8 @@
     <!-- Conteggio articoli filtrati -->
     <div id="resultInfo" class="text-sm text-slate-600">Caricamento…</div>
   </div>
+
+  <div id="categoryPanelMobileAnchor" class="lg:hidden mt-4 space-y-3"></div>
 
   <div id="listinoContainer" class="space-y-8 overflow-x-auto"></div>
 </section>

--- a/script.js
+++ b/script.js
@@ -216,8 +216,50 @@ const state = {
     name: '',                                       // Nominativo
     date: new Date().toISOString().slice(0, 10),    // yyyy-mm-dd
   },
-selectedCategory: 'Tutte',   // 👈 QUI la nuova proprietà
+  selectedCategory: 'Tutte',   // 👈 QUI la nuova proprietà
 };
+
+let categoryLayoutBound = false;
+
+function relocateCategoryPanel(){
+  const panel = document.getElementById('catsSticky');
+  const desktopAnchor = document.getElementById('categoryPanelDesktopAnchor');
+  const mobileAnchor = document.getElementById('categoryPanelMobileAnchor');
+  if (!panel || !desktopAnchor || !mobileAnchor) return;
+
+  const isDesktop = window.matchMedia ? window.matchMedia('(min-width: 1024px)').matches : window.innerWidth >= 1024;
+  const target = isDesktop ? desktopAnchor : mobileAnchor;
+  if (target && panel.parentElement !== target) {
+    target.appendChild(panel);
+  }
+}
+
+function applyCategoryOrientation(){
+  const list = document.getElementById('categoryList');
+  if (!list) return;
+
+  const isDesktop = window.matchMedia
+    ? window.matchMedia('(min-width: 1024px)').matches
+    : window.innerWidth >= 1024;
+  const orientation = isDesktop ? 'vertical' : 'horizontal';
+
+  list.classList.remove('orientation-horizontal', 'orientation-vertical');
+  list.classList.add(`orientation-${orientation}`);
+}
+
+function initCategoryLayout(){
+  if (categoryLayoutBound) return;
+  categoryLayoutBound = true;
+
+  const handleLayoutChange = () => {
+    relocateCategoryPanel();
+    applyCategoryOrientation();
+  };
+
+  handleLayoutChange();
+  window.addEventListener('resize', handleLayoutChange);
+  window.addEventListener('orientationchange', handleLayoutChange);
+}
 
 /* ============ BOOT ROBUSTO ============ */
 async function boot(){
@@ -335,6 +377,8 @@ function bindUI(){
   const msg = document.getElementById('quoteMsg');
   if (msg) msg.textContent = 'Preventivo svuotato.';
   });
+
+  initCategoryLayout();
 }
 
 function toggleModal(id, show=true){
@@ -643,7 +687,7 @@ function buildCategories(){
   allBtn.type = 'button';
   allBtn.textContent = 'TUTTE';
   allBtn.className = [
-    'block w-full text-left',
+    'inline-flex items-center justify-center w-full text-left',
     'rounded-xl border px-3 py-2 text-sm',
     'transition',
     (state.selectedCategory === 'Tutte')
@@ -660,7 +704,7 @@ scrollToProductsHeader();   // 👈 porta in vista anche il campo "Cerca prodott
 
   // separatore per andare a capo
   const br = document.createElement('div');
-  br.className = 'w-full h-0 my-2';
+  br.className = 'category-break w-full h-0 my-2';
   box.appendChild(br);
 
   // --- Altre categorie: chip su righe successive, no duplicati ---
@@ -669,7 +713,7 @@ scrollToProductsHeader();   // 👈 porta in vista anche il campo "Cerca prodott
     btn.type = 'button';
     btn.textContent = cat;
     btn.className = [
-      'inline-flex items-left justify-center',
+      'inline-flex items-center justify-center w-full text-left',
       'rounded-xl border px-3 py-1.5 text-sm',
       'transition',
       (state.selectedCategory === cat)
@@ -685,8 +729,7 @@ scrollToProductsHeader();   // 👈 porta in vista anche il campo "Cerca prodott
     box.appendChild(btn);
   });
 
-  // stile del contenitore (se non l’hai già messo in HTML)
-  box.classList.add('flex','flex-wrap','gap-2','items-start');
+  applyCategoryOrientation();
 }
 
 /* ============ RENDER SWITCH ============ */


### PR DESCRIPTION
## Summary
- remove the orientation toggle and demo preview so the category panel just shows the live list
- automatically switch the category list to the horizontal layout on mobile devices without storing user preferences

## Testing
- not run (Supabase-authenticated data required)

------
https://chatgpt.com/codex/tasks/task_e_68e570d49e948321b83cf52be383165d