### PR TITLE
Anchor category filter scroll during category search

### DIFF
--- a/script.js
+++ b/script.js
@@ -470,6 +470,7 @@ const state = {
   selectedCategory: 'Tutte',   // 👈 QUI la nuova proprietà
   categorySearch: '',
   categoryLetter: '',
+  categoryProductFilters: {},
   agent: {
     name: '',
     code: '',
@@ -1319,6 +1320,7 @@ function buildCategories(){
   const hasSearch = !!normalizedSearch;
 
   const handleCategorySelection = (category) => {
+    state.categoryProductFilters = {}; // reset filtri di categoria quando si cambia sezione
     state.selectedCategory = category;
     renderView();        // aggiorna listino
     buildCategories();   // aggiorna evidenziazione
@@ -1472,13 +1474,54 @@ function renderListino(){
   if (!cats.length){ container.innerHTML='<div class="text-slate-500 py-10 text-center">Nessun articolo.</div>'; return; }
 
   for (const cat of cats){
-    const items = byCat.get(cat).sort((a,b)=>(a.codice||'').localeCompare(b.codice||'','it'));
+    const catFilterRaw = state.categoryProductFilters?.[cat] ?? '';
+    const catFilter = normalize(catFilterRaw);
+    const catKey = encodeURIComponent(cat);
+    const items = byCat
+      .get(cat)
+      .filter(p => !catFilter || normalize(`${p.codice||''} ${(p.descrizione||'')} ${(p.tags||[]).join(' ')}`).includes(catFilter))
+      .sort((a,b)=>(a.codice||'').localeCompare(b.codice||'','it'));
 
     // Titolo categoria
     const h = document.createElement('h2');
     h.className='text-lg font-semibold mt-2 mb-1';
     h.textContent=cat;
     container.appendChild(h);
+
+    const filterWrap = document.createElement('div');
+    filterWrap.className = 'mb-2 flex items-center gap-2';
+
+    const filterLabel = document.createElement('label');
+    filterLabel.className = 'text-xs font-medium text-slate-600 uppercase tracking-wide';
+    filterLabel.textContent = 'Filtra categoria';
+    filterWrap.appendChild(filterLabel);
+
+    const filterInput = document.createElement('input');
+    filterInput.type = 'search';
+    filterInput.placeholder = 'Cerca solo in questa categoria';
+    filterInput.className = 'flex-1 rounded-xl border px-3 py-1.5 text-sm';
+    filterInput.value = catFilterRaw;
+    filterInput.dataset.catFilter = catKey;
+    filterInput.addEventListener('input', (e) => {
+      const { selectionStart, selectionEnd } = e.target;
+      const prevTop = e.target.getBoundingClientRect().top;
+      const prevScrollY = window.scrollY;
+      state.categoryProductFilters[cat] = e.target.value;
+      renderListino();
+      const nextInput = document.querySelector(`input[data-cat-filter="${catKey}"]`);
+      if (nextInput) {
+        nextInput.focus();
+        const start = typeof selectionStart === 'number' ? selectionStart : nextInput.value.length;
+        const end = typeof selectionEnd === 'number' ? selectionEnd : start;
+        nextInput.setSelectionRange(start, end);
+        const nextTop = nextInput.getBoundingClientRect().top;
+        const delta = nextTop - prevTop;
+        window.scrollTo({ top: prevScrollY + delta });
+      }
+    });
+    filterWrap.appendChild(filterInput);
+
+    container.appendChild(filterWrap);
 
     // Tabella
     const table = document.createElement('table');


### PR DESCRIPTION
## Summary
- preserve scroll position relative to the active category filter input while typing so the page doesn't jump
- maintain caret/focus restoration after re-rendering category-filtered results

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bfabe54108321954c7a4d4f6da0f8)