### PR TITLE
fix: harden price list publishing and notifications

### DIFF
--- a/README_SUPABASE.txt
+++ b/README_SUPABASE.txt
@@ -4,8 +4,17 @@ Contiene:
 - script.js (fetch sicuro da Supabase, solo lettura per agenti)
 - sw.js (PWA senza cache per Supabase)
 - supabase_schema.sql (schema + RLS)
-- functions/publish_price_list.ts, functions/notify_agents.ts (scheletri)
+- functions/publish_price_list.ts, functions/notify_agents.ts
 Passi: crea progetto, lancia SQL, imposta bucket 'media' (privato), crea utenti/ruoli, deploy funzioni, inserisci URL/anon key in script.js, pubblica su GitHub Pages.
+
+Sicurezza funzioni
+------------------
+- publish_price_list accetta solo richieste POST di utenti autenticati con profilo role='admin'.
+- notify_agents accetta richieste admin oppure chiamate interne firmate con INTERNAL_FUNCTION_SECRET.
+- Configura lo stesso valore segreto su entrambe le funzioni:
+  supabase secrets set INTERNAL_FUNCTION_SECRET="valore-lungo-casuale"
+- Per evitare doppie pubblicazioni accidentali, publish_price_list usa x-version-label se presente; altrimenti usa la data corrente. Se la versione esiste gia, risponde 409 invece di creare un duplicato.
+- Per pubblicare piu listini nello stesso giorno, inviare un header x-version-label diverso, per esempio 2026-05-31-v2.
 
 FAQ rapidissima
 ----------------

--- a/functions/notify_agents.ts
+++ b/functions/notify_agents.ts
@@ -1,15 +1,157 @@
-// notify_agents.ts (scheletro)
+// notify_agents.ts
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-const RESEND_API_KEY=Deno.env.get('RESEND_API_KEY'); const WHATSAPP_TOKEN=Deno.env.get('WHATSAPP_TOKEN'); const WABA_PHONE_ID=Deno.env.get('WABA_PHONE_ID');
-Deno.serve(async (req)=>{ try{
-  const body=await req.json(); const { price_list_id, version_label } = body;
-  const SUPABASE_URL=Deno.env.get('SUPABASE_URL')!, SERVICE_KEY=Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!; const client=createClient(SUPABASE_URL,SERVICE_KEY);
-  const { data: changes } = await client.from('change_log').select('change_type').eq('price_list_id',price_list_id);
-  const total=changes?.length||0, created=changes?.filter(c=>c.change_type==='created').length||0, updated=changes?.filter(c=>c.change_type==='updated').length||0, removed=changes?.filter(c=>c.change_type==='removed').length||0;
-  const { data: agents } = await client.from('profiles').select('id,role,phone'); // per email usa webhook esterno o join con auth
-  const summary=`Aggiornamento listino ${version_label}: ${total} modifiche (+${created} nuovi, ${updated} aggiornati, ${removed} ritirati).`;
-  if(RESEND_API_KEY){ /* invio email (implementa come nel provider scelto) */ }
-  if(WHATSAPP_TOKEN && WABA_PHONE_ID){ for(const a of agents||[]){ if(!a.phone) continue; await fetch(`https://graph.facebook.com/v19.0/${WABA_PHONE_ID}/messages`,{ method:'POST', headers:{'Authorization':`Bearer ${WHATSAPP_TOKEN}`,'Content-Type':'application/json'}, body:JSON.stringify({ messaging_product:'whatsapp', to:a.phone, type:'template', template:{ name:'listino_update', language:{code:'it'}, components:[{type:'body',parameters:[{type:'text',text:version_label},{type:'text',text:String(total)}]}] } }) }); } }
-  return new Response(JSON.stringify({ok:true, sent_to:(agents||[]).length, summary}),{headers:{'content-type':'application/json'}});
-}catch(e){ return new Response(JSON.stringify({ok:false,error:String(e)}),{status:500,headers:{'content-type':'application/json'}}); }});
+
+const RESEND_API_KEY = Deno.env.get("RESEND_API_KEY");
+const WHATSAPP_TOKEN = Deno.env.get("WHATSAPP_TOKEN");
+const WABA_PHONE_ID = Deno.env.get("WABA_PHONE_ID");
+
+const corsHeaders = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-headers": "authorization, content-type, x-internal-secret",
+  "access-control-allow-methods": "POST, OPTIONS",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "content-type": "application/json" },
+  });
+}
+
+function requireEnv(name: string) {
+  const value = Deno.env.get(name);
+  if (!value) throw new Error(`Missing environment variable: ${name}`);
+  return value;
+}
+
+function getBearerToken(req: Request) {
+  const auth = req.headers.get("authorization") || "";
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] || "";
+}
+
+async function isAdminRequest(client: ReturnType<typeof createClient>, req: Request) {
+  const token = getBearerToken(req);
+  if (!token) return false;
+
+  const { data: userData, error: userError } = await client.auth.getUser(token);
+  if (userError || !userData.user) return false;
+
+  const { data: profile, error: profileError } = await client
+    .from("profiles")
+    .select("role")
+    .eq("id", userData.user.id)
+    .single();
+
+  return !profileError && profile?.role === "admin";
+}
+
+async function assertAllowed(client: ReturnType<typeof createClient>, req: Request) {
+  const internalSecret = Deno.env.get("INTERNAL_FUNCTION_SECRET");
+  const providedSecret = req.headers.get("x-internal-secret");
+
+  if (internalSecret && providedSecret === internalSecret) return true;
+  return await isAdminRequest(client, req);
+}
+
+async function sendWhatsapp(phone: string, versionLabel: string, total: number) {
+  if (!WHATSAPP_TOKEN || !WABA_PHONE_ID) {
+    return { ok: false, skipped: true, reason: "whatsapp_not_configured" };
+  }
+
+  const response = await fetch(`https://graph.facebook.com/v19.0/${WABA_PHONE_ID}/messages`, {
+    method: "POST",
+    headers: {
+      "authorization": `Bearer ${WHATSAPP_TOKEN}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      messaging_product: "whatsapp",
+      to: phone,
+      type: "template",
+      template: {
+        name: "listino_update",
+        language: { code: "it" },
+        components: [{
+          type: "body",
+          parameters: [
+            { type: "text", text: versionLabel },
+            { type: "text", text: String(total) },
+          ],
+        }],
+      },
+    }),
+  });
+
+  if (!response.ok) {
+    const details = await response.text();
+    return { ok: false, status: response.status, error: details.slice(0, 500) };
+  }
+
+  return { ok: true, status: response.status };
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  if (req.method !== "POST") return jsonResponse({ ok: false, error: "Metodo non consentito" }, 405);
+
+  try {
+    const supabaseUrl = requireEnv("SUPABASE_URL");
+    const serviceKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+    const client = createClient(supabaseUrl, serviceKey);
+
+    if (!(await assertAllowed(client, req))) {
+      return jsonResponse({ ok: false, error: "Non autorizzato" }, 403);
+    }
+
+    const body = await req.json();
+    const priceListId = String(body?.price_list_id || "").trim();
+    const versionLabel = String(body?.version_label || "").trim();
+    if (!priceListId || !versionLabel) {
+      return jsonResponse({ ok: false, error: "price_list_id e version_label sono obbligatori" }, 400);
+    }
+
+    const { data: changes, error: changesError } = await client
+      .from("change_log")
+      .select("change_type")
+      .eq("price_list_id", priceListId);
+    if (changesError) throw changesError;
+
+    const total = changes?.length || 0;
+    const created = changes?.filter((change) => change.change_type === "created").length || 0;
+    const updated = changes?.filter((change) => change.change_type === "updated").length || 0;
+    const removed = changes?.filter((change) => change.change_type === "removed").length || 0;
+    const summary = `Aggiornamento listino ${versionLabel}: ${total} modifiche (+${created} nuovi, ${updated} aggiornati, ${removed} ritirati).`;
+
+    const { data: agents, error: agentsError } = await client
+      .from("profiles")
+      .select("id,role,phone")
+      .in("role", ["agent", "admin"]);
+    if (agentsError) throw agentsError;
+
+    const results = [];
+    for (const agent of agents || []) {
+      if (!agent.phone) {
+        results.push({ id: agent.id, ok: false, skipped: true, reason: "missing_phone" });
+        continue;
+      }
+
+      const result = await sendWhatsapp(agent.phone, versionLabel, total);
+      results.push({ id: agent.id, ...result });
+    }
+
+    return jsonResponse({
+      ok: results.every((result) => result.ok || result.skipped),
+      sent_to: results.filter((result) => result.ok).length,
+      skipped: results.filter((result) => result.skipped).length,
+      failed: results.filter((result) => !result.ok && !result.skipped).length,
+      summary,
+      results,
+      email_configured: Boolean(RESEND_API_KEY),
+    });
+  } catch (error) {
+    console.error("[notify_agents]", error);
+    return jsonResponse({ ok: false, error: error instanceof Error ? error.message : String(error) }, 500);
+  }
+});

--- a/functions/publish_price_list.ts
+++ b/functions/publish_price_list.ts
@@ -1,29 +1,256 @@
-// publish_price_list.ts (scheletro)
+// publish_price_list.ts
 import "jsr:@supabase/functions-js/edge-runtime.d.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 import Papa from "https://esm.sh/papaparse@5.4.1";
-Deno.serve(async (req)=>{ try{
-  const SUPABASE_URL=Deno.env.get('SUPABASE_URL')!, SERVICE_KEY=Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
-  const client=createClient(SUPABASE_URL,SERVICE_KEY);
-  const ct=req.headers.get('content-type')||''; let rows:any[]=[];
-  if(ct.includes('text/csv')){ const csv=await req.text(); const parsed=Papa.parse(csv,{header:true}); rows=(parsed.data as any[]).filter(r=>r.Codice||r.Descrizione); }
-  else { rows=await req.json(); }
-  const map=(r:any)=>({ codice:String(r.Codice||'').trim(), descrizione:String(r.Descrizione||'').trim(), categoria:String(r.Categoria||'').trim(), sottocategoria:String(r.Sottocategoria||'').trim(), prezzo:r.Prezzo?Number(String(r.Prezzo).replace('.','').replace(',','.')):null, unita:String(r.Unita||'pz').trim(), disponibile:String(r.Disponibile||'').toLowerCase()==='si', novita:String(r.Novita||'').toLowerCase()==='si', pack:String(r.Pack||'').trim(), pallet:String(r.Pallet||'').trim(), tags:String(r.Tag||'').split(',').map((s:string)=>s.trim()).filter(Boolean), updated_at:new Date().toISOString() });
-  const incoming=rows.map(map).filter(x=>x.codice);
-  const { data: current } = await client.from('products').select('codice,prezzo,descrizione,disponibile,novita,tags');
-  const curBy=new Map((current||[]).map((p:any)=>[p.codice,p])); const created:any[]=[], updated:any[]=[], seen=new Set<string>();
-  for(const r of incoming){ seen.add(r.codice); const cur=curBy.get(r.codice); if(!cur){ created.push(r);} else { const delta:any={}; if(cur.prezzo!==r.prezzo) delta.prezzo={from:cur.prezzo,to:r.prezzo}; if(cur.descrizione!==r.descrizione) delta.descrizione={from:cur.descrizione,to:r.descrizione}; if(cur.disponibile!==r.disponibile) delta.disponibile={from:cur.disponibile,to:r.disponibile}; if(cur.novita!==r.novita) delta.novita={from:cur.novita,to:r.novita}; if(JSON.stringify(cur.tags||[])!==JSON.stringify(r.tags||[])) delta.tags={from:cur.tags,to:r.tags}; if(Object.keys(delta).length) updated.push({...r, delta}); } }
-  const removed=(current||[]).filter((p:any)=>!seen.has(p.codice));
-  const version=new Date().toISOString().slice(0,10);
-  const { data: pl } = await client.from('price_lists').insert({ version_label:version }).select('id').single();
-  const price_list_id=pl.id;
-  if(created.length) await client.from('products').insert(created);
-  for(const u of updated){ await client.from('products').update(u).eq('codice',u.codice); }
-  const changes:any[]=[]; created.forEach(c=>changes.push({price_list_id,codice:c.codice,change_type:'created',delta:null}));
-  updated.forEach(u=>changes.push({price_list_id,codice:u.codice,change_type:'updated',delta:u.delta}));
-  removed.forEach(r=>changes.push({price_list_id,codice:r.codice,change_type:'removed',delta:null}));
-  if(changes.length) await client.from('change_log').insert(changes);
-  const { data: snap } = await client.from('products').select('*'); if(snap?.length){ const items=snap.map((s:any)=>({price_list_id,...s})); items.forEach((i:any)=>{ delete i.id; }); await client.from('price_list_items').insert(items); }
-  await client.functions.invoke('notify_agents',{ body:{ price_list_id, version_label: version } });
-  return new Response(JSON.stringify({ok:true, version, created:created.length, updated:updated.length, removed:removed.length}),{headers:{'content-type':'application/json'}});
-}catch(e){ return new Response(JSON.stringify({ok:false,error:String(e)}),{status:500,headers:{'content-type':'application/json'}}); }});
+
+const corsHeaders = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-headers": "authorization, content-type, x-version-label, x-skip-notify",
+  "access-control-allow-methods": "POST, OPTIONS",
+};
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "content-type": "application/json" },
+  });
+}
+
+function requireEnv(name: string) {
+  const value = Deno.env.get(name);
+  if (!value) throw new Error(`Missing environment variable: ${name}`);
+  return value;
+}
+
+function getBearerToken(req: Request) {
+  const auth = req.headers.get("authorization") || "";
+  const match = auth.match(/^Bearer\s+(.+)$/i);
+  return match?.[1] || "";
+}
+
+async function assertAdmin(client: ReturnType<typeof createClient>, req: Request) {
+  const token = getBearerToken(req);
+  if (!token) return { ok: false as const, status: 401, error: "Token mancante" };
+
+  const { data: userData, error: userError } = await client.auth.getUser(token);
+  if (userError || !userData.user) {
+    return { ok: false as const, status: 401, error: "Sessione non valida" };
+  }
+
+  const { data: profile, error: profileError } = await client
+    .from("profiles")
+    .select("role")
+    .eq("id", userData.user.id)
+    .single();
+
+  if (profileError || profile?.role !== "admin") {
+    return { ok: false as const, status: 403, error: "Solo gli admin possono pubblicare il listino" };
+  }
+
+  return { ok: true as const, userId: userData.user.id };
+}
+
+function parseItalianNumber(value: unknown) {
+  const raw = String(value ?? "").trim();
+  if (!raw) return null;
+  const normalized = raw.replace(/\s/g, "").replace(/\./g, "").replace(",", ".");
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function parseBoolean(value: unknown, defaultValue = false) {
+  const raw = String(value ?? "").trim().toLowerCase();
+  if (!raw) return defaultValue;
+  return ["si", "yes", "true", "1", "x"].includes(raw);
+}
+
+function normalizeRow(row: Record<string, unknown>) {
+  const now = new Date().toISOString();
+  return {
+    codice: String(row.Codice ?? row.codice ?? "").trim(),
+    descrizione: String(row.Descrizione ?? row.descrizione ?? "").trim(),
+    categoria: String(row.Categoria ?? row.categoria ?? "").trim(),
+    sottocategoria: String(row.Sottocategoria ?? row.sottocategoria ?? "").trim(),
+    prezzo: parseItalianNumber(row.Prezzo ?? row.prezzo),
+    unita: String(row.Unita ?? row.unita ?? "pz").trim() || "pz",
+    disponibile: parseBoolean(row.Disponibile ?? row.disponibile, true),
+    novita: parseBoolean(row.Novita ?? row.novita, false),
+    pack: String(row.Pack ?? row.pack ?? "").trim(),
+    pallet: String(row.Pallet ?? row.pallet ?? "").trim(),
+    tags: String(row.Tag ?? row.Tags ?? row.tags ?? "")
+      .split(",")
+      .map((tag) => tag.trim())
+      .filter(Boolean),
+    updated_at: now,
+  };
+}
+
+function productPatch(row: Record<string, unknown>) {
+  const { delta: _delta, ...patch } = row;
+  return patch;
+}
+
+function buildVersionLabel(req: Request) {
+  const fromHeader = req.headers.get("x-version-label")?.trim();
+  if (fromHeader) return fromHeader;
+  return new Date().toISOString().slice(0, 10);
+}
+
+async function readRows(req: Request) {
+  const contentType = req.headers.get("content-type") || "";
+
+  if (contentType.includes("text/csv")) {
+    const csv = await req.text();
+    const parsed = Papa.parse(csv, { header: true, skipEmptyLines: true });
+    if (parsed.errors?.length) {
+      throw new Error(`CSV non valido: ${parsed.errors[0].message}`);
+    }
+    return (parsed.data as Record<string, unknown>[]).filter((row) => row.Codice || row.Descrizione);
+  }
+
+  const body = await req.json();
+  if (Array.isArray(body)) return body;
+  if (Array.isArray(body?.rows)) return body.rows;
+  throw new Error("Body non valido: inviare un array di righe o { rows: [...] }");
+}
+
+Deno.serve(async (req) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  if (req.method !== "POST") return jsonResponse({ ok: false, error: "Metodo non consentito" }, 405);
+
+  try {
+    const supabaseUrl = requireEnv("SUPABASE_URL");
+    const serviceKey = requireEnv("SUPABASE_SERVICE_ROLE_KEY");
+    const client = createClient(supabaseUrl, serviceKey);
+
+    const admin = await assertAdmin(client, req);
+    if (!admin.ok) return jsonResponse({ ok: false, error: admin.error }, admin.status);
+
+    const rows = await readRows(req);
+    const incoming = rows.map(normalizeRow).filter((row) => row.codice && row.descrizione);
+    if (!incoming.length) {
+      return jsonResponse({ ok: false, error: "Nessuna riga valida da pubblicare" }, 400);
+    }
+
+    const version = buildVersionLabel(req);
+    const { data: existingVersion, error: existingVersionError } = await client
+      .from("price_lists")
+      .select("id")
+      .eq("version_label", version)
+      .maybeSingle();
+
+    if (existingVersionError) throw existingVersionError;
+    if (existingVersion) {
+      return jsonResponse({
+        ok: false,
+        error: `La versione ${version} esiste gia. Usa x-version-label per pubblicare una nuova versione.`,
+      }, 409);
+    }
+
+    const { data: current, error: currentError } = await client
+      .from("products")
+      .select("codice,prezzo,descrizione,disponibile,novita,tags");
+    if (currentError) throw currentError;
+
+    const currentByCode = new Map((current || []).map((product: any) => [product.codice, product]));
+    const created: any[] = [];
+    const updated: any[] = [];
+    const seen = new Set<string>();
+
+    for (const row of incoming) {
+      seen.add(row.codice);
+      const existing = currentByCode.get(row.codice);
+      if (!existing) {
+        created.push(row);
+        continue;
+      }
+
+      const delta: Record<string, unknown> = {};
+      if (Number(existing.prezzo) !== row.prezzo) delta.prezzo = { from: existing.prezzo, to: row.prezzo };
+      if (existing.descrizione !== row.descrizione) delta.descrizione = { from: existing.descrizione, to: row.descrizione };
+      if (existing.disponibile !== row.disponibile) delta.disponibile = { from: existing.disponibile, to: row.disponibile };
+      if (existing.novita !== row.novita) delta.novita = { from: existing.novita, to: row.novita };
+      if (JSON.stringify(existing.tags || []) !== JSON.stringify(row.tags || [])) {
+        delta.tags = { from: existing.tags, to: row.tags };
+      }
+
+      if (Object.keys(delta).length) updated.push({ ...row, delta });
+    }
+
+    const removed = (current || []).filter((product: any) => !seen.has(product.codice));
+
+    const { data: priceList, error: priceListError } = await client
+      .from("price_lists")
+      .insert({ version_label: version, published_by: admin.userId })
+      .select("id")
+      .single();
+    if (priceListError) throw priceListError;
+
+    const priceListId = priceList.id;
+
+    if (created.length) {
+      const { error } = await client.from("products").insert(created);
+      if (error) throw error;
+    }
+
+    for (const row of updated) {
+      const { error } = await client.from("products").update(productPatch(row)).eq("codice", row.codice);
+      if (error) throw error;
+    }
+
+    for (const row of removed) {
+      const { error } = await client
+        .from("products")
+        .update({ disponibile: false, novita: false, updated_at: new Date().toISOString() })
+        .eq("codice", row.codice);
+      if (error) throw error;
+    }
+
+    const changes = [
+      ...created.map((row) => ({ price_list_id: priceListId, codice: row.codice, change_type: "created", delta: null })),
+      ...updated.map((row) => ({ price_list_id: priceListId, codice: row.codice, change_type: "updated", delta: row.delta })),
+      ...removed.map((row: any) => ({ price_list_id: priceListId, codice: row.codice, change_type: "removed", delta: null })),
+    ];
+
+    if (changes.length) {
+      const { error } = await client.from("change_log").insert(changes);
+      if (error) throw error;
+    }
+
+    const { data: snapshot, error: snapshotError } = await client.from("products").select("*");
+    if (snapshotError) throw snapshotError;
+
+    if (snapshot?.length) {
+      const items = snapshot.map((product: any) => {
+        const { id: _id, ...rest } = product;
+        return { price_list_id: priceListId, ...rest };
+      });
+      const { error } = await client.from("price_list_items").insert(items);
+      if (error) throw error;
+    }
+
+    let notification: unknown = { ok: true, skipped: true };
+    if (req.headers.get("x-skip-notify") !== "true") {
+      const internalSecret = Deno.env.get("INTERNAL_FUNCTION_SECRET");
+      const authorization = req.headers.get("authorization") || undefined;
+      const { data, error } = await client.functions.invoke("notify_agents", {
+        body: { price_list_id: priceListId, version_label: version },
+        headers: internalSecret ? { "x-internal-secret": internalSecret } : authorization ? { authorization } : undefined,
+      });
+      notification = error ? { ok: false, error: error.message } : data;
+    }
+
+    return jsonResponse({
+      ok: true,
+      version,
+      price_list_id: priceListId,
+      created: created.length,
+      updated: updated.length,
+      removed: removed.length,
+      notification,
+    });
+  } catch (error) {
+    console.error("[publish_price_list]", error);
+    return jsonResponse({ ok: false, error: error instanceof Error ? error.message : String(error) }, 500);
+  }
+});

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -20,3 +20,9 @@ create policy "change_log read" on public.change_log for select using ( public.i
 create policy "price_lists write admin" on public.price_lists for all using ( public.is_admin(auth.uid()) ) with check ( public.is_admin(auth.uid()) );
 create policy "price_list_items write admin" on public.price_list_items for all using ( public.is_admin(auth.uid()) ) with check ( public.is_admin(auth.uid()) );
 create policy "change_log write admin" on public.change_log for all using ( public.is_admin(auth.uid()) ) with check ( public.is_admin(auth.uid()) );
+
+create index if not exists products_codice_idx on public.products (codice);
+create index if not exists products_categoria_idx on public.products (categoria);
+create index if not exists price_lists_published_at_idx on public.price_lists (published_at desc);
+create index if not exists price_list_items_price_list_id_idx on public.price_list_items (price_list_id);
+create index if not exists change_log_price_list_id_idx on public.change_log (price_list_id);


### PR DESCRIPTION
## Summary
- restrict `publish_price_list` to authenticated admins and validate request method/body before publishing
- prevent duplicate version labels, record `published_by`, handle Supabase errors, and avoid writing the internal `delta` field into `products`
- protect `notify_agents` with admin auth or `INTERNAL_FUNCTION_SECRET`, and return detailed sent/skipped/failed notification results
- add useful indexes for product/category lookups and price-list history
- document the new `INTERNAL_FUNCTION_SECRET` setup and version-label behavior

## Deployment notes
- Configure the shared function secret before deploying:
  `supabase secrets set INTERNAL_FUNCTION_SECRET="valore-lungo-casuale"`
- Redeploy both functions:
  `supabase functions deploy publish_price_list`
  `supabase functions deploy notify_agents`
- Run the added SQL indexes from `supabase_schema.sql` in Supabase SQL Editor.

## Testing
- Compared branch against `main`: 4 files changed only.
- Not run locally: Deno is not installed in this workspace.