### PR TITLE
feat: add admin price list import

### DIFF
--- a/admin-import.js
+++ b/admin-import.js
@@ -1,0 +1,242 @@
+// Admin import listino da Excel/CSV.
+(function(){
+  const SUPABASE_URL = 'https://wajzudbaezbyterpjdxg.supabase.co';
+  const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Indhanp1ZGJhZXpieXRlcnBqZHhnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTcxODA4MTUsImV4cCI6MjA3Mjc1NjgxNX0.MxaAqdUrppG2lObO_L5-SgDu8D7eze7mBf6S9rR_Q2w';
+
+  const FIELD_ALIASES = {
+    Codice: ['codice', 'cod. articolo', 'cod articolo', 'cod_articolo', 'articolo', 'sku', 'code'],
+    Descrizione: ['descrizione', 'descrizione articolo', 'desc', 'description'],
+    Categoria: ['categoria', 'cat', 'famiglia', 'gruppo merceologico', 'gruppo'],
+    Sottocategoria: ['sottocategoria', 'sotto categoria', 'subcategoria', 'linea'],
+    Prezzo: ['prezzo', 'prezzo listino', 'prezzo vendita', 'listino', 'price'],
+    Unita: ['unita', 'um', 'u.m.', 'unita misura'],
+    Disponibile: ['disponibile', 'attivo', 'abilitato', 'visibile'],
+    Novita: ['novita', 'new', 'nuovo'],
+    Pack: ['pack', 'imballo', 'conf', 'confezione'],
+    Pallet: ['pallet', 'bancale'],
+    Tag: ['tag', 'tags', 'etichette'],
+    Dimensione: ['dimensione', 'dimensioni', 'misure', 'formato'],
+    Conai: ['conai', 'conai/collo', 'conai collo'],
+    ConaiPerCollo: ['conai per collo', 'conai_per_collo', 'conai/collo'],
+  };
+
+  const state = { rows: [], client: null };
+  const $ = (id) => document.getElementById(id);
+  const normalize = (value) => String(value || '')
+    .normalize('NFD')
+    .replace(/\p{Diacritic}/gu, '')
+    .replace(/[_-]+/g, ' ')
+    .toLowerCase()
+    .trim();
+  const escapeHtml = (value) => String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+  function ensureClient(){
+    if (state.client) return state.client;
+    if (!window.supabase?.createClient) return null;
+    state.client = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    return state.client;
+  }
+
+  function setMessage(message, tone = 'info'){
+    const el = $('adminImportMsg');
+    if (!el) return;
+    el.textContent = message || '';
+    el.className = 'text-xs ' + (
+      tone === 'error' ? 'text-red-600' :
+      tone === 'success' ? 'text-emerald-700' :
+      'text-slate-600'
+    );
+  }
+
+  function setPanelVisible(visible){
+    $('adminImportPanel')?.classList.toggle('hidden', !visible);
+    $('adminImportRoleBadge')?.classList.toggle('hidden', !visible);
+  }
+
+  async function refreshRole(){
+    const client = ensureClient();
+    if (!client) return;
+    const { data: { session } } = await client.auth.getSession();
+    if (!session?.user) {
+      setPanelVisible(false);
+      return;
+    }
+    const { data: profile } = await client
+      .from('profiles')
+      .select('role')
+      .eq('id', session.user.id)
+      .maybeSingle();
+    setPanelVisible(profile?.role === 'admin');
+  }
+
+  function clearImport(){
+    state.rows = [];
+    const count = $('adminImportCount');
+    if (count) count.textContent = '0';
+    const btn = $('btnPublishPriceList');
+    if (btn) btn.disabled = true;
+    const preview = $('adminImportPreview');
+    if (preview) {
+      preview.innerHTML = '';
+      preview.classList.add('hidden');
+    }
+    setMessage('');
+  }
+
+  function findValue(row, targetField){
+    const aliases = [targetField, ...(FIELD_ALIASES[targetField] || [])].map(normalize);
+    for (const [key, value] of Object.entries(row || {})) {
+      if (aliases.includes(normalize(key))) return value;
+    }
+    return '';
+  }
+
+  function normalizeRow(row){
+    const normalized = {};
+    Object.keys(FIELD_ALIASES).forEach((field) => {
+      normalized[field] = findValue(row, field);
+    });
+    normalized.Codice = String(normalized.Codice || '').trim();
+    normalized.Descrizione = String(normalized.Descrizione || '').trim();
+    return normalized;
+  }
+
+  async function readRows(file){
+    const extension = file.name.split('.').pop()?.toLowerCase();
+    if (extension === 'csv') {
+      const text = await file.text();
+      const workbook = XLSX.read(text, { type: 'string' });
+      const sheet = workbook.Sheets[workbook.SheetNames[0]];
+      return XLSX.utils.sheet_to_json(sheet, { defval: '', raw: false });
+    }
+
+    const buffer = await file.arrayBuffer();
+    const workbook = XLSX.read(buffer, { type: 'array' });
+    const sheet = workbook.Sheets[workbook.SheetNames[0]];
+    return XLSX.utils.sheet_to_json(sheet, { defval: '', raw: false });
+  }
+
+  function renderPreview(rows){
+    const preview = $('adminImportPreview');
+    if (!preview) return;
+    if (!rows.length) {
+      preview.innerHTML = '';
+      preview.classList.add('hidden');
+      return;
+    }
+    const columns = ['Codice', 'Descrizione', 'Categoria', 'Prezzo', 'Unita', 'Disponibile', 'Novita'];
+    preview.innerHTML = `
+      <table class="w-full text-xs">
+        <thead class="bg-slate-100 text-slate-700">
+          <tr>${columns.map(col => `<th class="border-b px-2 py-2 text-left font-semibold">${escapeHtml(col)}</th>`).join('')}</tr>
+        </thead>
+        <tbody>
+          ${rows.slice(0, 8).map(row => `
+            <tr>${columns.map(col => `<td class="border-b px-2 py-2 align-top">${escapeHtml(row[col] ?? '')}</td>`).join('')}</tr>
+          `).join('')}
+        </tbody>
+      </table>
+    `;
+    preview.classList.remove('hidden');
+  }
+
+  async function handleFileChange(event){
+    try {
+      const file = event.target.files?.[0];
+      clearImport();
+      if (!file) return;
+      if (!window.XLSX) {
+        setMessage('Libreria Excel non caricata. Ricarica la pagina e riprova.', 'error');
+        return;
+      }
+
+      setMessage('Lettura file in corso...');
+      const rawRows = await readRows(file);
+      const validRows = rawRows.map(normalizeRow).filter(row => row.Codice && row.Descrizione);
+      state.rows = validRows;
+      $('adminImportCount').textContent = String(validRows.length);
+      $('btnPublishPriceList').disabled = validRows.length === 0;
+      renderPreview(validRows);
+
+      setMessage(
+        validRows.length
+          ? `${validRows.length} righe pronte da pubblicare.`
+          : 'Nessuna riga valida trovata. Verifica che il file abbia almeno Codice e Descrizione.',
+        validRows.length ? 'success' : 'error'
+      );
+    } catch (error) {
+      console.error('[AdminImport] file error', error);
+      clearImport();
+      setMessage('Errore nella lettura del file. Controlla formato e intestazioni.', 'error');
+    }
+  }
+
+  async function publishRows(){
+    const btn = $('btnPublishPriceList');
+    try {
+      if (!state.rows.length) {
+        setMessage('Carica prima un file listino valido.', 'error');
+        return;
+      }
+
+      const client = ensureClient();
+      const { data: { session }, error: sessionError } = await client.auth.getSession();
+      if (sessionError) throw sessionError;
+      if (!session?.access_token) {
+        setMessage('Sessione scaduta. Esci e rientra prima di pubblicare.', 'error');
+        return;
+      }
+
+      const versionLabel = String($('adminVersionLabel')?.value || '').trim();
+      const notifyAgents = !!$('adminNotifyAgents')?.checked;
+      const headers = {
+        Authorization: `Bearer ${session.access_token}`,
+        'x-skip-notify': notifyAgents ? 'false' : 'true',
+      };
+      if (versionLabel) headers['x-version-label'] = versionLabel;
+
+      btn.disabled = true;
+      setMessage('Pubblicazione listino in corso...');
+      const { data, error } = await client.functions.invoke('publish_price_list', {
+        body: { rows: state.rows },
+        headers,
+      });
+
+      if (error) throw error;
+      if (!data?.ok) throw new Error(data?.error || 'Pubblicazione non riuscita');
+
+      setMessage(`Listino pubblicato: ${data.version}. Nuovi ${data.created}, aggiornati ${data.updated}, ritirati ${data.removed}.`, 'success');
+      setTimeout(() => window.location.reload(), 1200);
+    } catch (error) {
+      console.error('[AdminImport] publish error', error);
+      setMessage(error?.message || 'Errore durante la pubblicazione del listino.', 'error');
+    } finally {
+      if (btn) btn.disabled = state.rows.length === 0;
+    }
+  }
+
+  function init(){
+    $('adminImportFile')?.addEventListener('change', handleFileChange);
+    $('btnPublishPriceList')?.addEventListener('click', () => { void publishRows(); });
+    const today = new Date().toISOString().slice(0, 10);
+    if ($('adminVersionLabel') && !$('adminVersionLabel').value) $('adminVersionLabel').value = today;
+    setPanelVisible(false);
+
+    const client = ensureClient();
+    client?.auth?.onAuthStateChange?.(() => { void refreshRole(); });
+    setTimeout(() => { void refreshRole(); }, 800);
+    document.addEventListener('appReady', () => { void refreshRole(); });
+    document.addEventListener('appHidden', () => setPanelVisible(false));
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/functions/publish_price_list.ts
+++ b/functions/publish_price_list.ts
@@ -69,9 +69,12 @@ function normalizeRow(row: Record<string, unknown>) {
   return {
     codice: String(row.Codice ?? row.codice ?? "").trim(),
     descrizione: String(row.Descrizione ?? row.descrizione ?? "").trim(),
+    dimensione: String(row.Dimensione ?? row.dimensione ?? "").trim(),
     categoria: String(row.Categoria ?? row.categoria ?? "").trim(),
     sottocategoria: String(row.Sottocategoria ?? row.sottocategoria ?? "").trim(),
     prezzo: parseItalianNumber(row.Prezzo ?? row.prezzo),
+    conai: parseItalianNumber(row.Conai ?? row.conai),
+    conai_per_collo: parseItalianNumber(row.ConaiPerCollo ?? row.conai_per_collo ?? row["CONAI/collo"]),
     unita: String(row.Unita ?? row.unita ?? "pz").trim() || "pz",
     disponibile: parseBoolean(row.Disponibile ?? row.disponibile, true),
     novita: parseBoolean(row.Novita ?? row.novita, false),
@@ -149,7 +152,7 @@ Deno.serve(async (req) => {
 
     const { data: current, error: currentError } = await client
       .from("products")
-      .select("codice,prezzo,descrizione,disponibile,novita,tags");
+      .select("codice,prezzo,descrizione,dimensione,conai,conai_per_collo,disponibile,novita,tags");
     if (currentError) throw currentError;
 
     const currentByCode = new Map((current || []).map((product: any) => [product.codice, product]));
@@ -168,6 +171,11 @@ Deno.serve(async (req) => {
       const delta: Record<string, unknown> = {};
       if (Number(existing.prezzo) !== row.prezzo) delta.prezzo = { from: existing.prezzo, to: row.prezzo };
       if (existing.descrizione !== row.descrizione) delta.descrizione = { from: existing.descrizione, to: row.descrizione };
+      if ((existing.dimensione || "") !== row.dimensione) delta.dimensione = { from: existing.dimensione, to: row.dimensione };
+      if (Number(existing.conai || 0) !== Number(row.conai || 0)) delta.conai = { from: existing.conai, to: row.conai };
+      if (Number(existing.conai_per_collo || 0) !== Number(row.conai_per_collo || 0)) {
+        delta.conai_per_collo = { from: existing.conai_per_collo, to: row.conai_per_collo };
+      }
       if (existing.disponibile !== row.disponibile) delta.disponibile = { from: existing.disponibile, to: row.disponibile };
       if (existing.novita !== row.novita) delta.novita = { from: existing.novita, to: row.novita };
       if (JSON.stringify(existing.tags || []) !== JSON.stringify(row.tags || [])) {

--- a/index.html
+++ b/index.html
@@ -314,7 +314,19 @@
       border-radius: .2rem;
       padding: 0 .12em;
     }
+.admin-panel {
+  border: 1px solid #cbd5e1;
+  background: #f8fafc;
+}
 
+.admin-preview {
+  max-height: 16rem;
+  overflow: auto;
+}
+
+.admin-preview table {
+  min-width: 760px;
+}
     @media (max-width: 767.98px) {
       .header-inner {
         flex-direction: column;
@@ -735,7 +747,46 @@
     <!-- Conteggio articoli filtrati -->
     <div id="resultInfo" class="text-sm text-slate-600">Caricamento…</div>
   </div>
+<div id="adminImportPanel" class="admin-panel hidden rounded-xl p-4 mb-4">
+  <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-1 sm:flex-row sm:items-center sm:justify-between">
+      <div>
+        <h3 class="text-sm font-semibold text-slate-900">Importa listino</h3>
+        <p class="text-xs text-slate-600">Carica il file Excel o CSV esportato da Ad Hoc.</p>
+      </div>
+      <span id="adminImportRoleBadge" class="hidden w-fit rounded-md bg-slate-200 px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-wide text-slate-700">Admin</span>
+    </div>
 
+    <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+      <div class="space-y-1">
+        <label for="adminImportFile" class="block text-xs font-medium uppercase tracking-wide text-slate-600">File listino</label>
+        <input id="adminImportFile" type="file" accept=".xlsx,.xls,.csv,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-excel"
+               class="w-full rounded-lg border bg-white px-3 py-2 text-sm">
+      </div>
+      <div class="grid grid-cols-2 gap-2 sm:flex sm:items-center">
+        <label class="inline-flex items-center gap-2 rounded-lg border bg-white px-3 py-2 text-sm text-slate-700">
+          <input id="adminNotifyAgents" type="checkbox" class="h-4 w-4 accent-sky-600">
+          Avvisa agenti
+        </label>
+        <button id="btnPublishPriceList" cl
+      </div>
+    </div>
+
+    <div class="grid gap-3 md:grid-cols-[minmax(0,1fr)_12rem]">
+      <div class="space-y-1">
+        <label for="adminVersionLabel" class="block text-xs font-medium uppercase tracking-wide text-slate-600">Versione</label>
+        <input id="adminVersionLabel" type="text" class="w-full rounded-lg border bg-white px-3 py-2 text-sm" placeholder="es. 2026-05-31-v2">
+      </div>
+      <div class="space-y-1">
+        <label class="block text-xs font-medium uppercase tracking-wide text-slate-600">Righe valide</label>
+        <div id="adminImportCount" class="rounded-lg border bg-white px-3 py-2 text-sm text-slate-700">0</div>
+      </div>
+    </div>
+
+    <div id="adminImportPreview" class="admin-preview hidden rounded-lg border bg-white"></div>
+    <p id="adminImportMsg" class="text-xs text-slate-600"></p>
+  </div>
+</div>
   <div id="categoryPanelMobileAnchor" class="lg:hidden mt-4 space-y-3"></div>
 
   <div id="listinoContainer" class="space-y-8 overflow-x-auto"></div>
@@ -878,8 +929,8 @@
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2/dist/umd/supabase.js"></script>
 
   <!-- forza aggiornamento -->
-  <script src="./script.js?v=tablet-drawer-10" defer></script>
-
+ <script src="./script.js?v=admin-import-1" defer></script>
+<script src="./admin-import.js?v=1" defer></script>
 <div id="floatingActions"
      class="fixed z-[9999]
             bottom-[max(1rem,env(safe-area-inset-bottom))]

--- a/supabase_schema.sql
+++ b/supabase_schema.sql
@@ -21,6 +21,10 @@ create policy "price_lists write admin" on public.price_lists for all using ( pu
 create policy "price_list_items write admin" on public.price_list_items for all using ( public.is_admin(auth.uid()) ) with check ( public.is_admin(auth.uid()) );
 create policy "change_log write admin" on public.change_log for all using ( public.is_admin(auth.uid()) ) with check ( public.is_admin(auth.uid()) );
 
+alter table public.price_list_items add column if not exists dimensione text;
+alter table public.price_list_items add column if not exists conai numeric(12,4);
+alter table public.price_list_items add column if not exists conai_per_collo numeric(12,4);
+
 create index if not exists products_codice_idx on public.products (codice);
 create index if not exists products_categoria_idx on public.products (categoria);
 create index if not exists price_lists_published_at_idx on public.price_lists (published_at desc);


### PR DESCRIPTION
## Cosa cambia
- Aggiunge un pannello admin in `index.html` per importare listini Excel/CSV esportati da Ad Hoc.
- Aggiunge `admin-import.js` per leggere il file, normalizzare le colonne e inviare il listino alla funzione Supabase.
- Estende `publish_price_list` per gestire anche dimensione, CONAI e CONAI per collo durante import, confronto e storico.
- Aggiorna lo schema con le colonne snapshot necessarie in `price_list_items`.

## Test
- `node --check admin-import.js`
- verifica diff PR: `admin-import.js`, `index.html`, `functions/publish_price_list.ts`, `supabase_schema.sql`

## Dopo il merge
- Eseguire in Supabase SQL Editor le tre `alter table` per `price_list_items`.
- Ridistribuire la Edge Function `publish_price_list` con il codice aggiornato.